### PR TITLE
Mention Japan work authorization on resume

### DIFF
--- a/src/_data/resume.yml
+++ b/src/_data/resume.yml
@@ -27,7 +27,7 @@ summary: |
   Seasoned software engineer with 20 years of experience building web applications and leading engineering teams.
   Deep expertise in Ruby on Rails, with a track record spanning product development, developer productivity, infrastructure, and engineering management.
 
-  Based in Japan since 2010.
+  Based in Japan since 2010 · Japan permanent resident · No visa sponsorship required.
 work:
   title: Work Experience
   entries:


### PR DESCRIPTION
Closes #137

Very short: makes Japan work authorization explicit in the resume summary.

Changes:
- Updates `resume.summary` to say: “Based in Japan since 2010 · Japan permanent resident · No visa sponsorship required.”

HTML output:
```html
<p class="summary">Seasoned software engineer with 20 years of experience building web applications and leading engineering teams.
Deep expertise in Ruby on Rails, with a track record spanning product development, developer productivity, infrastructure, and engineering management.
Based in Japan since 2010 · Japan permanent resident · No visa sponsorship required.</p>
```

Screenshot:
![Resume summary area](https://raw.githubusercontent.com/davidstosik/davidstosik.github.io/pr-screenshots/.github/pr-screenshots/pr-141-resume.png)

