### PR TITLE
Add manual resume last updated date

### DIFF
--- a/src/_data/resume.yml
+++ b/src/_data/resume.yml
@@ -1,4 +1,5 @@
 name: "David Stosik"
+updated_at: 2026-05-14
 headline: "Staff-level Ruby engineer with 20 years of experience"
 subheadline: "Writes high-quality software, tackles elusive bugs, grows strong engineers, builds with AI."
 socials:

--- a/src/resume-md.liquid
+++ b/src/resume-md.liquid
@@ -85,6 +85,6 @@ _{{ resume.subheadline }}_
 {% endfor %}
 ---
 
-{% if resume.updated_at %}_Last updated: {{ resume.updated_at | date: "%B %-d, %Y" }}_
+_Last updated: {{ resume.updated_at | date: "%B %-d, %Y" }}_
 
-{% endif %}_[Printable HTML version]({{ "/resume/" | absolute_url }})_
+_[Printable HTML version]({{ "/resume/" | absolute_url }})_

--- a/src/resume-md.liquid
+++ b/src/resume-md.liquid
@@ -85,4 +85,6 @@ _{{ resume.subheadline }}_
 {% endfor %}
 ---
 
-_[Printable HTML version]({{ "/resume/" | absolute_url }})_
+{% if resume.updated_at %}_Last updated: {{ resume.updated_at | date: "%B %-d, %Y" }}_
+
+{% endif %}_[Printable HTML version]({{ "/resume/" | absolute_url }})_

--- a/src/resume.liquid
+++ b/src/resume.liquid
@@ -92,6 +92,7 @@ permalink: /resume/
     .community-title { font-weight: 600; font-size: 14px; }
     .community-desc { font-size: 13px; color: var(--muted); }
     .llm-note { margin-top: 32px; padding-top: 16px; border-top: 1px solid var(--border); color: var(--muted); font-size: 13px; text-align: center; }
+    .last-updated { margin-top: 8px; color: var(--muted); font-size: 12px; text-align: center; }
     .print-only { display: none; }
     @media print { body { max-width: 860px; padding: 24px 28px; font-size: 12px; background: #fff; } .resume-page { padding: 0; box-shadow: none; } a { color: inherit; text-decoration: none; } .top-actions, .screen-only { display: none; } .print-only { display: inline; } header .left h1 { font-size: 28px; } header .left .headline { font-size: 14px; } header .left .subheadline, header .right { font-size: 13px; } h2 { font-size: 11px; } .summary { font-size: 13px; } .job-title { font-size: 14px; } .job-date, .job-company, .sub-team-date, .community-desc, .llm-note { font-size: 12px; } .job li, .sub-team-title, .skills-grid, .certs-grid, .lang-list, .community-title { font-size: 13px; } }
   </style>
@@ -229,6 +230,9 @@ permalink: /resume/
     <a class="screen-only" href="{{ "/resume.md" | relative_url }}">LLM-friendly Markdown version</a>
     <span class="print-only">LLM-friendly Markdown version available at {{ "/resume.md" | absolute_url }}</span>
   </p>
+  {% if resume.updated_at %}
+  <p class="last-updated">Last updated: {{ resume.updated_at | date: "%B %-d, %Y" }}</p>
+  {% endif %}
   </main>
 </body>
 </html>

--- a/src/resume.liquid
+++ b/src/resume.liquid
@@ -230,9 +230,7 @@ permalink: /resume/
     <a class="screen-only" href="{{ "/resume.md" | relative_url }}">LLM-friendly Markdown version</a>
     <span class="print-only">LLM-friendly Markdown version available at {{ "/resume.md" | absolute_url }}</span>
   </p>
-  {% if resume.updated_at %}
   <p class="last-updated">Last updated: {{ resume.updated_at | date: "%B %-d, %Y" }}</p>
-  {% endif %}
   </main>
 </body>
 </html>


### PR DESCRIPTION
Closes #138

Very short: adds a manually controlled “Last updated” date to the resume footer.

Changes:
- Adds `updated_at: 2026-05-14` to `src/_data/resume.yml`.
- Renders it near the Markdown/PDF note as subtle footer text.
- Also includes the same date in `/resume.md` so the Markdown resume stays in sync.

HTML output:
```html
<p class="last-updated">Last updated: May 14, 2026</p>
```

Markdown output:
```md
_Last updated: May 14, 2026_
```

Screenshot:
![Resume footer last updated area](https://raw.githubusercontent.com/davidstosik/davidstosik.github.io/pr-screenshots/.github/pr-screenshots/pr-142-resume.png)
