### PR TITLE
Render resume summary as Markdown

### DIFF
--- a/src/_data/resume.yml
+++ b/src/_data/resume.yml
@@ -21,6 +21,7 @@ socials:
 summary: |
   Seasoned software engineer with 20 years of experience building web applications and leading engineering teams.
   Deep expertise in Ruby on Rails, with a track record spanning product development, developer productivity, infrastructure, and engineering management.
+
   Based in Japan since 2010.
 work:
   title: Work Experience

--- a/src/resume.liquid
+++ b/src/resume.liquid
@@ -133,7 +133,7 @@ permalink: /resume/
 
   <section>
     <h2>Summary</h2>
-    <p class="summary">{{ resume.summary | strip | escape }}</p>
+    <div class="summary">{{ resume.summary | markdownify }}</div>
   </section>
 
   <section>

--- a/src/resume.liquid
+++ b/src/resume.liquid
@@ -70,6 +70,7 @@ permalink: /resume/
     section { margin-bottom: 28px; }
     h2 { font-size: 12px; font-weight: 700; text-transform: uppercase; letter-spacing: 1.2px; color: var(--accent); margin-bottom: 14px; padding-bottom: 4px; border-bottom: 1px solid var(--border); }
     .summary { font-size: 14px; color: var(--muted); line-height: 1.7; }
+    .summary p + p { margin-top: 0.8em; }
     .job { margin-bottom: 20px; }
     .job:last-child { margin-bottom: 0; }
     .job-header { display: flex; justify-content: space-between; align-items: baseline; gap: 8px; margin-bottom: 2px; }


### PR DESCRIPTION
Very short: allows Markdown syntax inside `resume.summary` to render in the HTML resume.

Changes:
- Replaces escaped plain-text rendering with `markdownify`.
- Wraps the generated Markdown HTML in `.summary` so existing styling still applies.
- Adds a blank line before “Based in Japan since 2010.” so it renders as a separate paragraph.
- Adds spacing between summary paragraphs so the split is visible in the HTML/PDF output.

HTML output:
```html
<div class="summary">
  <p>Seasoned software engineer with 20 years of experience building web applications and leading engineering teams.
Deep expertise in Ruby on Rails, with a track record spanning product development, developer productivity, infrastructure, and engineering management.</p>

  <p>Based in Japan since 2010.</p>
</div>
```

Markdown output remains clean:
```md
Deep expertise in Ruby on Rails, with a track record spanning product development, developer productivity, infrastructure, and engineering management.

Based in Japan since 2010.
```

Screenshot:
![Resume Markdown-rendered summary area](https://raw.githubusercontent.com/davidstosik/davidstosik.github.io/pr-screenshots/.github/pr-screenshots/pr-144-resume.png)
